### PR TITLE
Add real-time collaborative Markdown editor with live preview and version history

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+coverage/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,7 +1,37 @@
 # grogger
-A simple Frogger-inspired game where frogs collect grogs.
 
-## Requirements
+This repository now includes:
+
+1. The original `grogger.py` Pygame game.
+2. A real-time collaborative Markdown editor with live preview and version history.
+
+## Collaborative Markdown editor
+
+### Stack
+- **Frontend:** React + Vite, `react-markdown`, `rehype-sanitize`.
+- **Backend:** Node.js + Express + Socket.io.
+- **Testing:** Vitest + Testing Library.
+
+### Install
+```bash
+npm install
+```
+
+### Run the editor (frontend + backend)
+```bash
+npm run dev
+```
+- Frontend: `http://localhost:5173`
+- WebSocket/HTTP server: `http://localhost:3001`
+
+### Run tests
+```bash
+npm test
+```
+
+## Original game (still available)
+
+### Requirements
 - Python 3.11+
 - [Pygame](https://www.pygame.org/) library
 
@@ -10,10 +40,9 @@ Install the requirements with:
 pip install -r requirements.txt
 ```
 
-## Running the Game
-Execute the `grogger.py` script:
+### Running the game
 ```bash
 python grogger.py
 ```
-Use the arrow keys to move the frog. Avoid the cars and collect the blue grogs.
-Each grog collected will make the screen fuzzier.
+Use the arrow keys to move the frog. Avoid cars and collect the blue grogs.
+Each grog collected makes the screen fuzzier.

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,57 @@
+import express from 'express';
+import { createServer } from 'node:http';
+import { Server } from 'socket.io';
+import { DocumentSyncStore } from '../src/sync/documentSyncStore.js';
+
+const PORT = process.env.PORT || 3001;
+const app = express();
+const httpServer = createServer(app);
+const io = new Server(httpServer, {
+  cors: {
+    origin: '*'
+  }
+});
+const store = new DocumentSyncStore();
+
+app.get('/health', (_req, res) => {
+  res.json({ ok: true });
+});
+
+io.on('connection', (socket) => {
+  socket.on('document:join', ({ roomId = 'default-room', username = 'anonymous' } = {}) => {
+    socket.join(roomId);
+    socket.data.roomId = roomId;
+    socket.data.username = username;
+
+    socket.emit('document:state', store.getState(roomId));
+  });
+
+  socket.on('document:update', ({ roomId, content } = {}) => {
+    if (typeof content !== 'string' || !roomId) {
+      return;
+    }
+
+    const username = socket.data.username || 'anonymous';
+    const nextState = store.applyUpdate(roomId, content, username);
+
+    io.to(roomId).emit('document:state', nextState);
+  });
+
+  socket.on('document:restore', ({ roomId, versionId } = {}) => {
+    if (!roomId || !versionId) {
+      return;
+    }
+
+    const username = socket.data.username || 'anonymous';
+    const nextState = store.restoreVersion(roomId, versionId, username);
+
+    if (nextState) {
+      io.to(roomId).emit('document:state', nextState);
+    }
+  });
+});
+
+httpServer.listen(PORT, () => {
+  // eslint-disable-next-line no-console
+  console.log(`Socket.io server listening on http://localhost:${PORT}`);
+});

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Collaborative Markdown Editor</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,0 +1,53 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { EditorPane } from './components/EditorPane.jsx';
+import { PreviewPane } from './components/PreviewPane.jsx';
+import { VersionHistory } from './components/VersionHistory.jsx';
+import { createSocketClient } from './lib/socketClient.js';
+
+export default function App() {
+  const roomId = 'default-room';
+  const username = useMemo(() => `user-${Math.floor(Math.random() * 1000)}`, []);
+  const [content, setContent] = useState('Connecting...');
+  const [versions, setVersions] = useState([]);
+  const socketRef = useRef(null);
+
+  useEffect(() => {
+    const socket = createSocketClient();
+    socketRef.current = socket;
+
+    socket.emit('document:join', { roomId, username });
+
+    socket.on('document:state', (state) => {
+      setContent(state.content);
+      setVersions(state.versions);
+    });
+
+    return () => {
+      socket.disconnect();
+      socketRef.current = null;
+    };
+  }, [roomId, username]);
+
+  const handleChange = (nextValue) => {
+    setContent(nextValue);
+    socketRef.current?.emit('document:update', { roomId, content: nextValue });
+  };
+
+  const handleRestore = (versionId) => {
+    socketRef.current?.emit('document:restore', { roomId, versionId });
+  };
+
+  return (
+    <main style={{ fontFamily: 'Arial, sans-serif', padding: '1rem' }}>
+      <h1>Real-time Collaborative Markdown Editor</h1>
+      <p>
+        Room: <code>{roomId}</code> | User: <code>{username}</code>
+      </p>
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 300px', gap: '1rem' }}>
+        <EditorPane content={content} onChange={handleChange} />
+        <PreviewPane content={content} />
+        <VersionHistory versions={versions} onRestore={handleRestore} />
+      </div>
+    </main>
+  );
+}

--- a/frontend/src/components/EditorPane.jsx
+++ b/frontend/src/components/EditorPane.jsx
@@ -1,0 +1,13 @@
+export function EditorPane({ content, onChange }) {
+  return (
+    <section>
+      <h2>Editor</h2>
+      <textarea
+        aria-label="Markdown editor"
+        value={content}
+        onChange={(event) => onChange(event.target.value)}
+        style={{ width: '100%', minHeight: '320px', padding: '0.75rem', fontFamily: 'monospace' }}
+      />
+    </section>
+  );
+}

--- a/frontend/src/components/PreviewPane.jsx
+++ b/frontend/src/components/PreviewPane.jsx
@@ -1,0 +1,13 @@
+import ReactMarkdown from 'react-markdown';
+import rehypeSanitize from 'rehype-sanitize';
+
+export function PreviewPane({ content }) {
+  return (
+    <section>
+      <h2>Live Preview</h2>
+      <div aria-label="Markdown preview" style={{ border: '1px solid #ddd', minHeight: '320px', padding: '1rem' }}>
+        <ReactMarkdown rehypePlugins={[rehypeSanitize]}>{content}</ReactMarkdown>
+      </div>
+    </section>
+  );
+}

--- a/frontend/src/components/VersionHistory.jsx
+++ b/frontend/src/components/VersionHistory.jsx
@@ -1,0 +1,22 @@
+export function VersionHistory({ versions, onRestore }) {
+  const sorted = [...versions].reverse();
+
+  return (
+    <section>
+      <h2>Version History</h2>
+      <ul style={{ listStyle: 'none', padding: 0, margin: 0, maxHeight: '260px', overflowY: 'auto' }}>
+        {sorted.map((version) => (
+          <li key={version.id} style={{ borderBottom: '1px solid #efefef', padding: '0.5rem 0' }}>
+            <div>
+              <strong>{version.author}</strong>
+            </div>
+            <div>{new Date(version.timestamp).toLocaleString()}</div>
+            <button type="button" onClick={() => onRestore(version.id)}>
+              Restore
+            </button>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/frontend/src/lib/socketClient.js
+++ b/frontend/src/lib/socketClient.js
@@ -1,0 +1,9 @@
+import { io } from 'socket.io-client';
+
+const SOCKET_URL = import.meta.env.VITE_SOCKET_URL || 'http://localhost:3001';
+
+export function createSocketClient() {
+  return io(SOCKET_URL, {
+    transports: ['websocket']
+  });
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/frontend/src/testSetup.js
+++ b/frontend/src/testSetup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom/vitest';

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import { resolve } from 'node:path';
+
+export default defineConfig({
+  plugins: [react()],
+  root: resolve(__dirname),
+  build: {
+    outDir: resolve(__dirname, '../dist'),
+    emptyOutDir: true
+  },
+  server: {
+    port: 5173
+  },
+  test: {
+    environment: 'jsdom',
+    setupFiles: resolve(__dirname, './src/testSetup.js')
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "grogger-collab-editor",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "concurrently \"npm run server\" \"npm run client\"",
+    "server": "node backend/server.js",
+    "client": "vite --config frontend/vite.config.js",
+    "build": "vite build --config frontend/vite.config.js",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-markdown": "^9.0.1",
+    "rehype-sanitize": "^6.0.0",
+    "socket.io": "^4.8.1",
+    "socket.io-client": "^4.8.1"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.2.0",
+    "@vitejs/plugin-react": "^4.3.4",
+    "concurrently": "^9.1.2",
+    "jsdom": "^26.0.0",
+    "vite": "^6.2.2",
+    "vitest": "^3.0.8"
+  }
+}

--- a/src/sync/documentSyncStore.js
+++ b/src/sync/documentSyncStore.js
@@ -1,0 +1,61 @@
+const DEFAULT_CONTENT = '# Collaborative Markdown\n\nStart editing together!';
+
+export class DocumentSyncStore {
+  constructor(maxVersions = 50) {
+    this.maxVersions = maxVersions;
+    this.rooms = new Map();
+  }
+
+  ensureRoom(roomId) {
+    if (!this.rooms.has(roomId)) {
+      this.rooms.set(roomId, {
+        content: DEFAULT_CONTENT,
+        versions: [this.createVersion(DEFAULT_CONTENT)]
+      });
+    }
+
+    return this.rooms.get(roomId);
+  }
+
+  getState(roomId) {
+    const room = this.ensureRoom(roomId);
+    return {
+      content: room.content,
+      versions: [...room.versions]
+    };
+  }
+
+  applyUpdate(roomId, content, author = 'anonymous') {
+    const room = this.ensureRoom(roomId);
+    room.content = content;
+    room.versions.push(this.createVersion(content, author));
+
+    if (room.versions.length > this.maxVersions) {
+      room.versions = room.versions.slice(room.versions.length - this.maxVersions);
+    }
+
+    return this.getState(roomId);
+  }
+
+  restoreVersion(roomId, versionId, author = 'anonymous') {
+    const room = this.ensureRoom(roomId);
+    const found = room.versions.find((version) => version.id === versionId);
+
+    if (!found) {
+      return null;
+    }
+
+    return this.applyUpdate(roomId, found.content, `${author} (restore)`);
+  }
+
+  createVersion(content, author = 'system') {
+    return {
+      id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      content,
+      author,
+      timestamp: new Date().toISOString()
+    };
+  }
+}
+
+export { DEFAULT_CONTENT };

--- a/tests/documentSyncStore.test.js
+++ b/tests/documentSyncStore.test.js
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { DocumentSyncStore } from '../src/sync/documentSyncStore.js';
+
+describe('DocumentSyncStore synchronization', () => {
+  it('keeps room content in sync and appends history entries', () => {
+    const store = new DocumentSyncStore(10);
+
+    const initial = store.getState('room-1');
+    expect(initial.versions).toHaveLength(1);
+
+    const updated = store.applyUpdate('room-1', '# Title', 'alice');
+    expect(updated.content).toBe('# Title');
+    expect(updated.versions).toHaveLength(2);
+    expect(updated.versions.at(-1)?.author).toBe('alice');
+  });
+
+  it('restores a previous version by id', () => {
+    const store = new DocumentSyncStore(10);
+
+    const first = store.applyUpdate('room-2', 'first edit', 'bob');
+    const second = store.applyUpdate('room-2', 'second edit', 'bob');
+    const targetVersionId = first.versions.at(-1)?.id;
+
+    const restored = store.restoreVersion('room-2', targetVersionId, 'bob');
+
+    expect(second.content).toBe('second edit');
+    expect(restored?.content).toBe('first edit');
+    expect(restored?.versions.at(-1)?.author).toContain('restore');
+  });
+});

--- a/tests/previewXss.test.jsx
+++ b/tests/previewXss.test.jsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { PreviewPane } from '../frontend/src/components/PreviewPane.jsx';
+
+describe('PreviewPane security', () => {
+  it('sanitizes unsafe HTML/script content to reduce XSS risk', () => {
+    render(<PreviewPane content={'<script>alert("xss")</script><img src=x onerror=alert(1) />'} />);
+
+    const preview = screen.getByLabelText('Markdown preview');
+
+    expect(preview.innerHTML).not.toContain('<script>');
+    expect(preview.innerHTML).not.toContain('onerror=');
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a real-time collaborative Markdown editor integrated into the repository with live preview and version history for collaborative editing scenarios.
- Maintain safety by sanitizing rendered Markdown and add tests to guard synchronization and XSS-related regressions.
- Separate frontend and backend responsibilities so the editor can scale and run independently from the project’s original game.

### Description
- Add a Socket.io backend server at `backend/server.js` that exposes `document:join`, `document:update`, `document:restore` events and a `/health` endpoint connected to a shared `DocumentSyncStore`.
- Implement the synchronization core `DocumentSyncStore` in `src/sync/documentSyncStore.js` with `getState`, `applyUpdate`, `restoreVersion`, and bounded version history behavior.
- Add a React + Vite frontend under `frontend/` with componentized UI: `EditorPane`, `PreviewPane` (uses `react-markdown` + `rehype-sanitize`), `VersionHistory`, application lifecycle in `frontend/src/App.jsx`, and socket client in `frontend/src/lib/socketClient.js`.
- Add project scaffolding and scripts in `package.json`, testing setup and two tests: `tests/documentSyncStore.test.js` (sync/version behavior) and `tests/previewXss.test.jsx` (sanitization), plus update `README.md` and `.gitignore`.

### Testing
- Ran `node --check backend/server.js && node --check src/sync/documentSyncStore.js`, which succeeded.
- Created unit tests `tests/documentSyncStore.test.js` and `tests/previewXss.test.jsx` intended to run under `vitest`, but `npm install` failed in this environment with a `403 Forbidden` from the registry so `npm test`/`vitest` could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc84f1ac148323b0f893115c12a479)